### PR TITLE
feat: 탭 별 웨이팅 카드 필터링 및 반응형 ui 구현(완)

### DIFF
--- a/apps/nowait-admin/src/hooks/useGetReservationList.tsx
+++ b/apps/nowait-admin/src/hooks/useGetReservationList.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import userApi from "../utils/UserApi";
+import adminApi from "../utils/AdminApi";
 
 export interface Reservation {
   id: number;
@@ -27,11 +27,14 @@ const fetchReservations = async (
   storeId: number
 ): Promise<ReservationResponse> => {
   const token = localStorage.getItem("adminToken");
-  const res = await userApi.get<ApiResponse>(`/reservations/admin/${storeId}`, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  });
+  const res = await adminApi.get<ApiResponse>(
+    `/reservations/admin/${storeId}`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    }
+  );
   return res.data.response;
 };
 

--- a/apps/nowait-admin/src/hooks/usePostAdminLogin.tsx
+++ b/apps/nowait-admin/src/hooks/usePostAdminLogin.tsx
@@ -1,9 +1,9 @@
 // hooks/useLoginMutation.ts
 import { useMutation } from "@tanstack/react-query";
-import userApi from "../utils/UserApi";
+import adminApi from "../utils/AdminApi";
 
 const postLogin = (data: { email: string; password: string }) => {
-  return userApi.post(`/admin/users/login`, data);
+  return adminApi.post(`/admin/users/login`, data);
 };
 
 export const usePostLoginMutation = () => {

--- a/apps/nowait-admin/src/hooks/useUpdateReservationStatus.tsx
+++ b/apps/nowait-admin/src/hooks/useUpdateReservationStatus.tsx
@@ -1,5 +1,5 @@
 import { useMutation } from "@tanstack/react-query";
-import UserApi from "../utils/UserApi";
+import AdminApi from "../utils/AdminApi";
 export const useUpdateReservationStatus = () => {
   const token = localStorage.getItem("adminToken");
 
@@ -11,7 +11,7 @@ export const useUpdateReservationStatus = () => {
       reservationId: number;
       status: "WAITING" | "CALLING" | "CONFIRMED" | "CANCELLED" | "NO_SHOW";
     }) => {
-      const res = await UserApi.patch(
+      const res = await AdminApi.patch(
         `/reservations/admin/updates/${reservationId}`,
         { status },
         {

--- a/apps/nowait-admin/src/utils/AdminApi.tsx
+++ b/apps/nowait-admin/src/utils/AdminApi.tsx
@@ -1,12 +1,12 @@
 import axios from "axios";
 
-const API_URL = import.meta.env.VITE_USER_API_URL;
+const API_URL = import.meta.env.VITE_ADMIN_API_URL;
 // 자유게시판 전체 데이터
-const UserApi = axios.create({
+const AdminApi = axios.create({
   baseURL: API_URL,
   headers: {
     "Content-Type": "application/json",
   },
 });
 
-export default UserApi;
+export default AdminApi;


### PR DESCRIPTION
## 작업 내용
탭 별 웨이팅 카드 필터링 및 반응형 ui 구현 완료
## 문제점 및 어려움
미입장 카드 반응형 ui 구현 (백엔드 없이 프론트 단에서 해결)
## 해결 방안
미입장 상태인 카드들의 id를 따로 리스트로 관리
## 공유 사항
테스트 요청. 현재 타이머는 빠른 테스트를 위해 10초만 작동하도록 설정