### PR TITLE
refactor: api 부분 코드 간소화

### DIFF
--- a/apps/nowait-user/src/hooks/useAuth.ts
+++ b/apps/nowait-user/src/hooks/useAuth.ts
@@ -1,23 +1,20 @@
 import { useQuery } from "@tanstack/react-query";
-import axios from "axios";
+import UserApi from "../utils/UserApi";
 
 // 토큰 갱신 함수
 export const refreshToken = async (): Promise<string | null> => {
   try {
-    const SERVER_URI = import.meta.env.VITE_SERVER_URI;
     const currentToken = localStorage.getItem("accessToken");
 
     if (!currentToken) {
       return null;
     }
-    // 3번쨰 파라미터 설정을 하기 위해 2번째 파라미터에 빈 객체를 넣어 전달.
-    const response = await axios.post(
-      `${SERVER_URI}/api/refresh-token`,
+
+    // UserApi 사용으로 헤더 설정 자동화
+    const response = await UserApi.post(
+      "/api/refresh-token",
       {},
       {
-        headers: {
-          Authorization: `Bearer ${currentToken}`,
-        },
         withCredentials: true, // HttpOnly 쿠키 포함
       }
     );

--- a/apps/nowait-user/src/utils/UserApi.tsx
+++ b/apps/nowait-user/src/utils/UserApi.tsx
@@ -1,0 +1,23 @@
+import axios from "axios";
+
+const API_URI = import.meta.env.VITE_SERVER_URI;
+
+const UserApi = axios.create({
+  baseURL: API_URI,
+});
+
+// 요청 인터셉터를 추가하여 매 요청마다 최신 토큰을 헤더에 설정
+UserApi.interceptors.request.use(
+  (config) => {
+    const currentToken = localStorage.getItem("accessToken");
+    if (currentToken) {
+      config.headers.Authorization = `Bearer ${currentToken}`;
+    }
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);
+
+export default UserApi;


### PR DESCRIPTION
## 작업 내용
매번 api 연동 시 헤더를 붙여야하는 부분 간소화.
## 문제점 및 어려움
로컬 스토리지 내에 있는 accessToken이 api 호출마다 매번 최신화되지 않아 에러가 발생하였음.
## 해결 방안
인터셉터를 추가하여 매 요청마다 최신 토큰을 헤더에 설정하였다.
## 공유 사항
앞으로 api 호출 시 UserApi.tsx를 사용하면 좀 더 간편한 api 구현 가능.